### PR TITLE
Fix edge case -- 0.5% of UIDs got wrong result

### DIFF
--- a/plugins/supported_cards/saflok.c
+++ b/plugins/supported_cards/saflok.c
@@ -66,8 +66,8 @@ void generate_saflok_key(const uint8_t *uid, uint8_t *key) {
     uint8_t carry_sum = 0;
 
     for (int i = KEY_LENGTH - 1; i >= 0; i--, magickal_index--) {
-        uint16_t keysum = temp_key[i] + magic_table[magickal_index];
-        temp_key[i] = (keysum & 0xFF) + carry_sum;
+        uint16_t keysum = temp_key[i] + magic_table[magickal_index] + carry_sum;
+        temp_key[i] = (keysum & 0xFF);
         carry_sum = keysum >> 8;
     }
 


### PR DESCRIPTION
The carry bit should have been applied to the summation **_before_** saving the result.

Only a small percentage of UIDs affected, because required that both `carry_sum` low byte was `0xff` and that carry flag from prior addition was non-zero.
